### PR TITLE
Avoid use of the FastShutCollectPosition channel for debugging purposes

### DIFF
--- a/HardwareObjects/ALBA/ALBACollect.py
+++ b/HardwareObjects/ALBA/ALBACollect.py
@@ -948,8 +948,8 @@ class ALBACollect(AbstractCollect):
         self.wait_supervisor_ready()
         self.logger.debug("Sending supervisor to sample view phase")
         self.close_fast_shutter()
-        if not self.supervisor_hwobj.is_fast_shutter_in_collect_position():
-            self.close_safety_shutter()
+        #if not self.supervisor_hwobj.is_fast_shutter_in_collect_position():
+        self.close_safety_shutter()
             
         self.supervisor_hwobj.go_sample_view()
 

--- a/HardwareObjects/ALBA/ALBASupervisor.py
+++ b/HardwareObjects/ALBA/ALBASupervisor.py
@@ -66,7 +66,7 @@ class ALBASupervisor(Device):
         self.chan_state = self.getChannelObject("state")
         self.chan_phase = self.getChannelObject("phase")
         self.chan_detector_cover = self.getChannelObject("detector_cover_open")
-        self.chan_fast_shutter_collect_position = self.getChannelObject("FastShutCollectPosition")
+        #self.chan_fast_shutter_collect_position = self.getChannelObject("FastShutCollectPosition")
 
         self.chan_state.connectSignal("update", self.state_changed)
         self.chan_phase.connectSignal("update", self.phase_changed)


### PR DESCRIPTION
Hi Jordi, this is a preparation for removing the channel from supervisor.xml in bl13_mxcube_config, without loosing the helical functionality
Thanks,
Roeland.